### PR TITLE
line-height 0 to footnotes

### DIFF
--- a/frontend/css/common.css
+++ b/frontend/css/common.css
@@ -43,12 +43,14 @@ figcaption {
 a.figure_reference {
 
 }
+
 a.footnote-reference {
 	vertical-align:super;
 	font-size:10px;
 	margin-right:0;
 	text-decoration:none;
 	font-family: Arial, Helvetica, sans-serif;
+	line-height: 0;
 }
 
 #section.oscitk_multi_column figure.html_figure .figure_content {


### PR DESCRIPTION
Adding line-height of 0 to footnotes so that it does not falsely contribute to content.height(). Footnotes were increasing the content height, however were not being included in the content.height() calculation.
